### PR TITLE
Fix typo

### DIFF
--- a/lib/P5pack.pm6
+++ b/lib/P5pack.pm6
@@ -100,7 +100,7 @@ my sub pack($template, *@items) is export {
     my int $elems = @items.elems;
     my $repeat;
 
-    sub putabyte(--> Nil) {
+    sub put-a-byte(--> Nil) {
         if $pos < $elems {
             my $data = @items.AT-POS($pos++);
             fill($data ~~ Str ?? $data.encode !! $data,0,0)
@@ -204,7 +204,7 @@ my sub pack($template, *@items) is export {
 
     # make sure this has the same order as the %dispatch initialization
     my @dispatch =
-      -> --> Nil { putabyte() },                                    # a
+      -> --> Nil { put-a-byte() },                                  # a
       -> --> Nil { fill( $pos < $elems ?? ascii() !! (),0x20,0) },  # A
       -> --> Nil { one() },                                         # c
       -> --> Nil { one() },                                         # C

--- a/t/02-single.t
+++ b/t/02-single.t
@@ -21,8 +21,11 @@ my uint $i3 = 0x9876543210987654; # not handled correctly by Rakudo
  is pack('a',    $s1),      Buf.new(0x73);
  is pack('a3',   $s1),      Buf.new(0x73, 0x74, 0x72);
  is pack('A',    $s1),      Buf.new(0x73);
+ is pack('A9',   $s1),      Buf.new(115,116,114,105,110,103,32,32,32);
  is pack('A3',   $s1),      Buf.new(0x73, 0x74, 0x72);
  is pack('c',    @a1),      Buf.new(123);
+ is pack('c5',   @a1),      Buf.new(123,97,130,0,0);
+ is pack('c0',   @a1),      Buf.new();
  is pack('c3',   @a1),      Buf.new(123, 97, 130);
  is pack('c3',   @a2),      Buf.new(123, 97, 130);
  is pack('C',    @a1),      Buf.new(123);


### PR DESCRIPTION
Fixes a typo in p5pack and adds a test for unpack, as well as an auxiliary sub for converting strings into blobs. 